### PR TITLE
dependency: remove pysha3, use eth-hash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pysha3==1.0.2
+eth-hash==0.5.2
 pytest>=6.2.0
 pytest-cov
 ecdsa==0.16.1

--- a/thor_devkit/cry/keccak.py
+++ b/thor_devkit/cry/keccak.py
@@ -2,9 +2,12 @@
 Keccak
 
 Keccak hash function.
+
+Note:   Keccak is different from standard SHA3
+        So the haslib.sha3_256() cannot be used to compute keccak_256()
 '''
 
-import sha3  # pysha3
+from eth_hash.auto import keccak
 from typing import List, Tuple
 
 
@@ -22,8 +25,9 @@ def keccak256(list_of_bytes: List[bytes]) -> Tuple[bytes, int]:
     Tuple[bytes, int]
         Hash value in bytes and length of bytes.
     '''
-    m = sha3.keccak_256()
+    m = keccak.new(b'')
     for item in list_of_bytes:
         m.update(item)
 
-    return m.digest(), m.digest_size
+    _digest = m.digest()
+    return _digest, len(_digest)


### PR DESCRIPTION
As `pysha3` is deprecated and ceased to exist, I am forced to find an alternative to `sha3.keccak_256()`.

Python > 3.6 < 3.11 has no default `keccak` implementation. the newest `sha3` included in default > Python3.6 isn't `keccak` since year 2015 the standard has changed. And Ethereum is using an obsolete standard.

So the solution is to use a standalone package that is the same as Ethereum implementation, aka, `eth-hash`.